### PR TITLE
We have a project files which treats warning as error. This will throw a...

### DIFF
--- a/Masonry/MASConstraintMaker.m
+++ b/Masonry/MASConstraintMaker.m
@@ -75,9 +75,12 @@
 }
 
 - (MASConstraint *)addConstraintWithAttributes:(MASAttribute)attrs {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
     MASAttribute anyAttribute = MASAttributeLeft | MASAttributeRight | MASAttributeTop | MASAttributeBottom | MASAttributeLeading | MASAttributeTrailing | MASAttributeWidth | MASAttributeHeight | MASAttributeCenterX | MASAttributeCenterY | MASAttributeBaseline;
     
     NSAssert((attrs & anyAttribute) != 0, @"You didn't pass any attribute to make.attributes(...)");
+#pragma clang diagnostic pop
     
     NSMutableArray *attributes = [NSMutableArray array];
     


### PR DESCRIPTION
...n unused warning when NSAssert is compiled out.
